### PR TITLE
Fix code scanning alert no. 7: XML external entity expansion

### DIFF
--- a/core/appHandler.js
+++ b/core/appHandler.js
@@ -232,7 +232,7 @@ module.exports.bulkProductsLegacy = function (req,res){
 
 module.exports.bulkProducts =  function(req, res) {
 	if (req.files.products && req.files.products.mimetype=='text/xml'){
-		var products = libxmljs.parseXmlString(req.files.products.data.toString('utf8'), {noent:true,noblanks:true})
+		var products = libxmljs.parseXmlString(req.files.products.data.toString('utf8'), {noblanks:true})
 		products.root().childNodes().forEach( product => {
 			var newProduct = new db.Product()
 			newProduct.name = product.childNodes()[0].text()


### PR DESCRIPTION
Fixes [https://github.com/fzzbb4aan2vu/playground-dvna/security/code-scanning/7](https://github.com/fzzbb4aan2vu/playground-dvna/security/code-scanning/7)

To fix the problem, we need to disable external entity expansion when parsing the XML data. This can be achieved by removing the `noent` option or setting it to `false`. This change ensures that no external entities are expanded during XML parsing, mitigating the risk of XXE attacks.

**Steps to fix:**
1. Modify the call to `libxmljs.parseXmlString` to remove the `noent` option or set it to `false`.
2. Ensure that the XML parsing still functions correctly without the `noent` option.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
